### PR TITLE
🚨[Hotfix/dev2]: 프론트 Merge 후 빌드 오류 해결 - 중복 메서드 및 누락된 변수 수정

### DIFF
--- a/app/src/main/java/tetris/ui/SettingsManager.java
+++ b/app/src/main/java/tetris/ui/SettingsManager.java
@@ -84,10 +84,6 @@ public class SettingsManager {
         return keyHardDrop;
     }
 
-    public String getGameMode() {
-        return gameMode;
-    }
-
     public void setVolume(double volume) {
         this.volume = Math.max(0.0, Math.min(100.0, volume));
     }
@@ -134,10 +130,6 @@ public class SettingsManager {
 
     public void setKeyHardDrop(String key) {
         this.keyHardDrop = key.toUpperCase();
-    }
-
-    public void setGameMode(String gameMode) {
-        this.gameMode = gameMode;
     }
 
     public void resetToDefaults() {

--- a/app/src/main/java/tetris/ui/controllers/MainMenuController.java
+++ b/app/src/main/java/tetris/ui/controllers/MainMenuController.java
@@ -69,7 +69,8 @@ public class MainMenuController implements Initializable {
         
         // 메뉴 버튼 리스트 초기화 (왼쪽에서 오른쪽, 위에서 아래 순서)
         menuButtons = new ArrayList<>();
-        menuButtons.add(startButton);
+        menuButtons.add(normalModeButton);
+        menuButtons.add(itemModeButton);
         menuButtons.add(scoreBoardButton);
         menuButtons.add(settingsButton);
         menuButtons.add(exitButton);
@@ -90,7 +91,7 @@ public class MainMenuController implements Initializable {
         
         // 첫 번째 버튼 선택
         selectButton(0);
-        startButton.requestFocus();
+        normalModeButton.requestFocus();
     }
 
     public void setSceneManager(SceneManager sceneManager) {

--- a/app/src/main/resources/fxml/MainMenu.fxml
+++ b/app/src/main/resources/fxml/MainMenu.fxml
@@ -7,6 +7,7 @@
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.text.Font?>
 
 <StackPane xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="tetris.ui.controllers.MainMenuController">
    <children>


### PR DESCRIPTION
 # 🚨 HotFix: 빌드 오류 해결 - 중복 메서드 및 누락된 변수 수정

  ## 📋 Summary
  빌드 실패를 야기하는 컴파일 오류 3건과 런타임 오류 1건을 수정하여 프로젝트가 정상적으로 빌드 및 실행되도록 수정했습니다.        

  ## 🐛 Issues Fixed
  - 빌드 시 4개의 컴파일 오류 발생
  - 실행 시 FXML 로드 오류 발생
  - 애플리케이션 실행 불가 상태

  ## 🔧 Changes

  ### 1. SettingsManager.java
  **문제점:**
  - Line 87: `getGameMode()` 메서드 중복 정의
  - Line 139: `setGameMode(String)` 메서드 중복 정의

  **해결 방법:**
  ```java
  // 제거: 중복된 getGameMode() (line 87-89)
  // 제거: 중복된 setGameMode() (line 139-141)
  // 유지: 기존 메서드 (line 63-65, 115-117)
```
  2. MainMenuController.java

  문제점:
  - Line 72: 존재하지 않는 startButton 변수 참조
  - Line 93: startButton.requestFocus() 호출 실패

  해결 방법:
  // Before
  menuButtons.add(startButton);
  startButton.requestFocus();

  // After
  menuButtons.add(normalModeButton);
  menuButtons.add(itemModeButton);
  normalModeButton.requestFocus();

  3. MainMenu.fxml

  문제점:
  - Line 22: Font 클래스를 찾을 수 없음
  - JavaFX FXML 로드 실패

  해결 방법:
  <!-- 추가 -->
  <?import javafx.scene.text.Font?>

  ✅ Testing

  - ./gradlew build 성공
  - ./gradlew test 통과
  - ./gradlew run 정상 실행
  - 메인 메뉴 UI 정상 표시 확인
  - 일반 모드/아이템 모드 버튼 정상 작동

  📊 Impact

  - 파일 수정: 3개
  - 추가된 줄: 4줄
  - 제거된 줄: 10줄
  - 영향 범위: UI 레이어 (MainMenu, Settings)

  📝 Additional Notes

  - 긴급 수정 사항으로 빌드 차단 이슈 해결
  - 기존 기능에 대한 영향 없음
  - UI/UX 변경 사항 없음

  🔗 Related

  - Branch: hotfix
  - Merge target: main / dev
  ---

## 결과 화면
---
<img width="752" height="1109" alt="image" src="https://github.com/user-attachments/assets/296bec7d-0f88-4ccc-9ea5-e20e7c071cc5" />
  🤖 Generated with https://claude.com/claude-code

  Co-Authored-By: Claude noreply@anthropic.com